### PR TITLE
OR-4050_Label_Studio_update_setup_scripts

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -47,9 +47,8 @@ numpy==1.24.3
 ordered_set==4.0.2
 #pandas>=0.24.0
 protobuf>=3.15.5
-psycopg2-binary==2.9.1
-python_dateutil==2.8.2
 psycopg2-binary==2.9.6
+python_dateutil==2.8.2
 pydantic>=1.7.3,<=1.11.0
 python_dateutil==2.8.1
 pytz ~=2022.1


### PR DESCRIPTION
Reason:
```
#7 45.23 Collecting psycopg2-binary==2.9.1
#7 45.24   Downloading psycopg2_binary-2.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)
#7 45.26      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 173.5 MB/s eta 0:00:00
#7 45.27 ERROR: Cannot install label-studio==1.8.3.dev0 because these package versions have conflicting dependencies.
#7 45.27 
#7 45.27 The conflict is caused by:
#7 45.27     label-studio 1.8.3.dev0 depends on psycopg2-binary==2.9.1
#7 45.27     label-studio 1.8.3.dev0 depends on psycopg2-binary==2.9.6
#7 45.27 
#7 45.27 To fix this you could try to:
#7 45.27 1. loosen the range of package versions you've specified
#7 45.27 2. remove package versions to allow pip attempt to solve the dependency conflict
#7 45.27 
#7 45.27 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
#7 ERROR: executor failed running [/bin/sh -c apt-get update &&     apt-get install -y nodejs  &&     apt-get install npm -y &&     git clone --depth 1 https://github.com/logivations/label-studio.git &&     cd label-studio &&     pip install -e . &&     cd label_studio/frontend/ &&     npm install &&     npm ci &&     npx webpack &&     cd ../.. &&     apt clean &&     rm -rf /var/lib/apt/lists/*]: exit code: 1
```