### PR TITLE
OR_4243_Labelstudio_Change_prediction_upload_algorithm

### DIFF
--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -400,7 +400,6 @@ def get_storages_for_delete(queryset):
     storages = []
     data = []
     for task in queryset:
-        print(f"task: {task}")
         for link_name in settings.IO_STORAGES_IMPORT_LINK_NAMES:
             if hasattr(task, link_name):
                 attr = getattr(task, link_name)
@@ -419,10 +418,9 @@ def delete_local_storage(data, storages):
     """
     for path in data:
         if os.path.exists(path):
-            print(f"Removed image from: {path}")
             os.remove(path)
         else:
-            print("The file does not exist")
+            logger.info("The file does not exist")
     for storage in storages:
         if not storage.links.all():
             if storage.title in storage.path:
@@ -430,7 +428,7 @@ def delete_local_storage(data, storages):
                     for name in dirs:
                         os.rmdir(os.path.join(root, name))
                 os.rmdir(storage.path)
-                print("dir removed")
+                logger.info(f"Removed: {storage.path}")
             storage.delete()
 
 

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -877,8 +877,9 @@ def remove_predictions_from_project(sender, instance, **kwargs):
 @receiver(post_save, sender=Prediction)
 def save_predictions_to_project(sender, instance, **kwargs):
     """Add predictions counters"""
-    instance.task.total_predictions = instance.task.predictions.all().count()
-    instance.task.save(update_fields=['total_predictions'])
+    task_id = instance.task_id
+    predictions_count = Prediction.objects.filter(task_id=task_id).count()
+    Task.objects.filter(id=task_id).update(total_predictions=predictions_count + 1)
     logger.debug(f"Updated total_predictions for {instance.task.id}.")
 
 # =========== END OF PROJECT SUMMARY UPDATES ===========

--- a/label_studio/tasks/urls.py
+++ b/label_studio/tasks/urls.py
@@ -21,6 +21,7 @@ _api_urlpatterns = [
 ]
 
 _api_annotations_urlpatterns = [
+    path('', api.AnnotationAPI.as_view(), name='annotation-post'),
     path('<int:pk>/', api.AnnotationAPI.as_view(), name='annotation-detail'),
     path('<int:pk>/convert-to-draft', api.AnnotationConvertAPI.as_view(), name='annotation-convert-to-draft'),
 ]


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
We figured out that 90% of the time during the prediction generation is spend during prediction upload to the label studio backend:

this is caused by posting each prediction individually to the backend
this is probably causing a separate update to the database as well
Please rewrite the algorithm to use bulk_create to significantly increase the data download speed.


#### What does this fix?
- In PredictitonAPI, the create() method has been added, which parses the incoming request into individual Prediction objects and saves them using bulk_create(). 
- The post_save() signal was changed to optimize work with the database
- In AnnotationAPI the post() method has been added, which parses the incoming request into individual Annotation objects and saves them using transaction.atomic.

#### What is the new behavior?
Now on my test dataset with 1300 images, predictions are saved to the database in 7 seconds instead of 1 minute 30 seconds. And the same annotation count uploads in ~15 seconds instead of ~ 2 minute.


### Does this PR introduce a breaking change?
_(check only one)_
- [x] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)

