### PR TITLE
OR-4067_Labelstudio_Runtime_error_on_storage_filename_filter

### DIFF
--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -238,6 +238,16 @@ def add_user_filter(enabled, key, _filter, filter_expressions):
         return 'continue'
 
 
+def create_storage_filename_querryset(task_ids):
+    """
+    Create a TaskQuerrySet object from array of task ids.
+    :param task_ids: array of tasks ids.
+    :return: filtered TaskQuerrySet
+    """
+    from tasks.models import Task
+    return Task.objects.filter(id__in=task_ids)
+
+
 def apply_filters(queryset, filters, project, request):
     logger.warning(queryset, filters, project, request)
     if not filters:
@@ -264,6 +274,13 @@ def apply_filters(queryset, filters, project, request):
         if filter_expression:
             filter_expressions.append(filter_expression)
             continue
+
+        if field_name == 'storage_filename':
+            task_ids = []
+            for task in queryset:
+                if _filter.value in task.storage_filename:
+                    task_ids.append(task.id)
+            return create_storage_filename_querryset(task_ids)
 
         # annotators
         result = add_user_filter(field_name == 'annotators', 'annotations__completed_by', _filter, filter_expressions)


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_
When filtering for the storage filename a Runtime Exception occurs:
![image](https://github.com/HumanSignal/label-studio/assets/146328908/92ec0d90-b151-477b-bdaf-0b3e820bbec6)



#### What does this fix?
_(if this is a bug fix)_
Because the storage_filename its @property field we cannot filter uses default Django filtering, so i added new condition that processes filtering tasks by the right way.