### PR TITLE
OR-4087_Labelstudio_Add_meta_information_for_tasks_during_image_upload

### DIFF
--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -237,17 +237,6 @@ def add_user_filter(enabled, key, _filter, filter_expressions):
         filter_expressions.append(Q(**{key+'__isnull': value}))
         return 'continue'
 
-
-def create_storage_filename_querryset(task_ids):
-    """
-    Create a TaskQuerrySet object from array of task ids.
-    :param task_ids: array of tasks ids.
-    :return: filtered TaskQuerrySet
-    """
-    from tasks.models import Task
-    return Task.objects.filter(id__in=task_ids)
-
-
 def apply_filters(queryset, filters, project, request):
     logger.warning(queryset, filters, project, request)
     if not filters:
@@ -275,12 +264,28 @@ def apply_filters(queryset, filters, project, request):
             filter_expressions.append(filter_expression)
             continue
 
+        if field_name.startswith("meta"):
+            _, key, tag = field_name.split('.')
+            task_ids = []
+            for task in queryset:
+                if key in task.meta:
+                    if tag in task.meta[key]:
+                        if task.meta[key][tag] == _filter.value:
+                            task_ids.append(task.id)
+
+            q = Q(id__in=task_ids)
+            filter_expressions.append(q)
+            continue
+
         if field_name == 'storage_filename':
             task_ids = []
             for task in queryset:
                 if _filter.value in task.storage_filename:
                     task_ids.append(task.id)
-            return create_storage_filename_querryset(task_ids)
+
+            q = Q(id__in=task_ids)
+            filter_expressions.append(q)
+            continue
 
         # annotators
         result = add_user_filter(field_name == 'annotators', 'annotations__completed_by', _filter, filter_expressions)

--- a/label_studio/io_storages/api.py
+++ b/label_studio/io_storages/api.py
@@ -102,7 +102,14 @@ class ImportStorageSyncAPI(generics.GenericAPIView):
         return ImportStorageClass.objects.all()
 
     def post(self, request, *args, **kwargs):
+        """
+        A method that accepts requests for create tasks
+        """
         storage = self.get_object()
+        if 'meta' in request.data and isinstance(request.data["meta"], dict):
+            storage.meta['tags'] = request.data["meta"]
+        else:
+            storage.meta['tags'] = None
         # check connectivity & access, raise an exception if not satisfied
         storage.validate_connection()
         storage.sync()

--- a/label_studio/io_storages/base_models.py
+++ b/label_studio/io_storages/base_models.py
@@ -96,10 +96,8 @@ class StorageInfo(models.Model):
         self.status = self.Status.QUEUED
 
         # reset and init meta
-        self.meta = {
-            'attempts': self.meta.get('attempts', 0) + 1,
-            'time_queued': str(timezone.now())
-        }
+        self.meta['attempts'] = self.meta.get('attempts', 0) + 1
+        self.meta['time_queued'] = str(timezone.now())
 
         self.save(update_fields=['last_sync_job', 'last_sync', 'last_sync_count', 'status', 'meta'])
 
@@ -337,7 +335,7 @@ class ImportStorage(Storage):
                 data=data, project=project, overlap=maximum_annotations,
                 is_labeled=len(annotations) >= maximum_annotations, total_predictions=len(predictions),
                 total_annotations=len(annotations) - cancelled_annotations,
-                cancelled_annotations=cancelled_annotations, inner_id=max_inner_id
+                cancelled_annotations=cancelled_annotations, inner_id=max_inner_id, meta=storage.meta["tags"]
             )
 
             link_class.create(task, key, storage)

--- a/label_studio/io_storages/localfiles/serializers.py
+++ b/label_studio/io_storages/localfiles/serializers.py
@@ -13,7 +13,9 @@ class LocalFilesImportStorageSerializer(ImportStorageSerializer):
     class Meta:
         model = LocalFilesImportStorage
         fields = '__all__'
-
+        extra_kwargs = {
+            'meta': {'required': False},
+        }
     def validate(self, data):
         # Validate local file path
         data = super(LocalFilesImportStorageSerializer, self).validate(data)

--- a/label_studio/projects/urls.py
+++ b/label_studio/projects/urls.py
@@ -46,6 +46,7 @@ _api_urlpatterns = [
 
     # Tasks list for the project: get and destroy
     path('<int:pk>/tasks/', api.ProjectTaskListAPI.as_view(), name='project-tasks-list'),
+    path('<int:pk>/tagged-tasks/', api.ProjectTaggedTaskListAPI.as_view(), name='project-tasks-list'),
 
     # Generate sample task for this project
     path('<int:pk>/sample-task/', api.ProjectSampleTask.as_view(), name='project-sample-task'),


### PR DESCRIPTION
### PR fulfills these requirements
- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Backend (Database)
- [x] Backend (API)
- [ ] Frontend


Reason for change:

The problem:

- our datasets often have manually crafted training/validation/test splits, but we cannot import this meta information to labels studio
- long term we want to have one project per use case (warehouse object detection, empty floor segmentation, conveyor belt segmentation..)
to make training of generalized models easier, to easily evaluation exiting models on new data from potentially new customers.
We need to store the information about data origin somewhere
- similarly we might want to retain additional information, like camera id, issue id etc, to evaluate for dataset balances
Please extend image uploading with a form that you can:
- click on upload images
- select a zip file or some files
- fill out a form for specifying the (training/validation/test) tag
- fill out a form for specifying an additional custom tag

After submitting the form the following should happen:
- images are uploaded
- tasks are generated for new images
configured tags are saved into the meta json only for the freshly generated images of that upload

Changes in this PR:

- Added new URLs for getting tagged tasks (/api/projects/{project_id}/tagged-tasks)
with the required body {"train": true, "test": false, "val": false} and returns the filtered tasks in the response.
- Added a new view for filtering tasks by tags.
— Advanced view of the synchronized image with additional fields for tags and saving it in the task model. {"tags": {"train": true, "test": false, "val": false, "custom_name": custom_value}}

Result:
As results we can add tags by swagger ui using this optional templates:
For upload {"tags": {"train": true, "test": false, "val": false, "custom_name": custom_value}}
For export/train: {"train": true, "test": false, "val": false, "custom_name": custom_value}
